### PR TITLE
Combine fix for SSL proxy problems with big-endian buffer problems

### DIFF
--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -376,6 +376,11 @@ class ForecastModel(object):
             if key not in query_variables:
                 continue
             squeezed = data[:].squeeze()
+
+            # If the data is big endian, swap the byte order to make it little endian
+            if squeezed.dtype.byteorder == '>':
+                squeezed = squeezed.byteswap().newbyteorder()
+                
             if squeezed.ndim == 1:
                 data_dict[key] = squeezed
             elif squeezed.ndim == 2:


### PR DESCRIPTION
This PR combines my fix to allow for SSL connections without verification which is useful for users working behind a corporate proxy and the bug solution to big-endian buffer problems.  
